### PR TITLE
Remove locked revisions from the manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,3 @@ git = "https://github.com/sfackler/rust-postgres"
 
 [dependencies.r2d2]
 git = "https://github.com/sfackler/r2d2"
-rev = "28c28642e643bbf8275ee4ef641eef2b8f53a88f"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -52,7 +52,7 @@ fn test_basic() {
         let conn = pool1.get().unwrap();
         s1.send(());
         r2.recv();
-        conn.replace();
+        drop(conn);
     });
 
     let pool2 = pool.clone();
@@ -60,11 +60,11 @@ fn test_basic() {
         let conn = pool2.get().unwrap();
         s2.send(());
         r1.recv();
-        conn.replace();
+        drop(conn);
     });
 
     fut1.get();
     fut2.get();
 
-    pool.get().unwrap().replace();
+    pool.get().unwrap();
 }


### PR DESCRIPTION
For rationale, see sfackler/rust-postgres#55
