### PR TITLE
Use the fresh Postgres driver.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ path = "tests/test.rs"
 
 [dependencies]
 r2d2 = "0.5"
-postgres = "0.7"
+postgres = "0.8"


### PR DESCRIPTION
Track the fresh PostgreSQL driver in order not to fall into problems with multiple versions of the postgres crate.