### PR TITLE
Pub crates types are used

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! Postgres support for the `r2d2` connection pool.
 #![doc(html_root_url="https://sfackler.github.io/r2d2-postgres/doc/v0.10.1")]
 #![warn(missing_docs)]
-extern crate r2d2;
-extern crate postgres;
+pub extern crate r2d2;
+pub extern crate postgres;
 
 use std::error;
 use std::error::Error as _StdError;


### PR DESCRIPTION
With current version we have to duplicate dependencies `r2d2_postgres` uses.

```rust
extern crate r2d2;
extern crate r2d2_postgres;
extern crate postgres;
```

and `Cargo.toml`:

``` toml
[dependencies]
r2d2 = ">= 0.6, < 0.8"
postgres = "0.11"
r2d2_postgres = "0.10.1"
```

Sometimes it gives an error:

```rust
    = note: expected type `&[&postgres::types::ToSql]`
    = note:    found type `&[&postgres::types::ToSql]`
note: Perhaps two different versions of crate `postgres` are being used?
```

This PR makes possible to use one dependency only:

```rust
extern crate r2d2_postgres;
use r2d2_postgres::r2d2;
use r2d2_postgres::postgres;
```

``` toml
[dependencies]
r2d2_postgres = "0.10.1"
```
