### PR TITLE
Use reexported postgres for NoTls in examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.40.0
+      - image: rust:1.42.0
       - image: postgres:12
         environment:
           POSTGRES_PASSWORD: password

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ r2d2-postgres
 
 ```rust
 use std::thread;
-use postgres::{NoTls, Client};
-use r2d2_postgres::PostgresConnectionManager;
+use r2d2_postgres::{postgres::NoTls, PostgresConnectionManager};
 
 fn main() {
     let manager = PostgresConnectionManager::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,7 @@ use r2d2::ManageConnection;
 ///
 /// ```no_run
 /// use std::thread;
-/// use postgres::{NoTls, Client};
-/// use r2d2_postgres::PostgresConnectionManager;
+/// use r2d2_postgres::{postgres::NoTls, PostgresConnectionManager};
 ///
 /// fn main() {
 ///     let manager = PostgresConnectionManager::new(


### PR DESCRIPTION
As we just discussed in #23. Rather than a big warning in the `README` about specific versions of the Postgres library which you'd have to remember to manually update, I just made the examples use the reexported library as you suggested.

I removed the `use postgres::Client` since that wasn't actually getting used in the example and was generating a warning.