### PR TITLE
Implement more minimal health check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ where
     }
 
     fn is_valid(&self, client: &mut Client) -> Result<(), Error> {
-        client.simple_query("SELECT 1;").map(|_| ())
+        client.simple_query("").map(|_| ())
     }
 
     fn has_broken(&self, client: &mut Client) -> bool {


### PR DESCRIPTION
Currently the is_valid function uses `SELECT 1;` to check on the health of a connection but this can be improved a bit by replacing it with an empty query. I believe this accomplishes the same thing as the current state of code and saves the query from needing to go the planning stage in the postgres server.

See psycopg's implementation for example:
https://github.com/psycopg/psycopg/pull/791